### PR TITLE
Submit date and time as UTC

### DIFF
--- a/cloudlogbashcat.sh
+++ b/cloudlogbashcat.sh
@@ -122,7 +122,7 @@ while true; do
            \"radio\":\"$cloudlogRadioId\",
            \"frequency\":\"$rigFreq\",
            \"mode\":\"$rigMode\",
-           \"timestamp\":\"$(date +"%Y/%m/%d %H:%M")\"
+           \"timestamp\":\"$(date -u +"%Y/%m/%d %H:%M")\"
          }" $cloudlogApiUrl >/dev/null 2>&1
   fi
 


### PR DESCRIPTION
Cloudlog always showed a warning like "Radio connection timed-out: CloudlogBashCat data is -X minutes old". With X being either 60 or 120, depending on DST.

This patch fixes that, by sending date and time as UTC.