### PR TITLE
Allow the script to but run as a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,22 @@ A simple script to keep Cloudlog in synch with rigctld or flrig
 
 * Edit the config file - instructions contained within!
 * Run it with ``./cloudlogbashcat.sh``
+
+### Run as a systemd service
+
+To run this process in the background on bootup, we can install
+is as a systemd service. Note that you'll need to update the
+service file to point to the correct directory. Once you've
+done this, install by:
+
+```bash
+# Create a symlink to the service file. This will allow git to update the service file later
+cd CloudlogBashCat
+sudo ln -s $(pwd)/cloudlogbashcat.service /etc/systemd/system/cloudlogbashcat.service
+
+# Reload the systemctl daemon
+sudo systemctl daemon-reload
+
+# Enable and start the new service
+sudo systemctl enable --now cloudlogbashcat
+```

--- a/cloudlogbashcat.service
+++ b/cloudlogbashcat.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=CloudlogBashCat
+After=network.target
+StartLimitBurst=2
+StartLimitInterval=30
+
+[Service]
+ExecStartPre=/bin/sleep 10
+Restart=on-failure
+RestartSec=5
+
+# Note: Update the path to your script here
+ExecStart=/opt/programs/CloudlogBashCat/cloudlogbashcat.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/cloudlogbashcat.sh
+++ b/cloudlogbashcat.sh
@@ -29,6 +29,8 @@ rigOldMode="NO MATCH"
 delay=1
 
 # load in config ...
+cur_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $cur_dir
 source cloudlogbashcat.conf
 
 simpleArg() {


### PR DESCRIPTION
I've added a systemd service file that allows the script to launch on startup, and run in the background.  
  
It required a very minor update to the original script, just so that we could source the correct file.