### PR TITLE
Explicity mention FLRig server in .config

### DIFF
--- a/cloudlogbashcat.conf
+++ b/cloudlogbashcat.conf
@@ -13,8 +13,7 @@ cloudlogApiKey="1234567890123456"
 # What rig control software are we connecting to? (rigctld or flrig)
 rigControlSoftware=flrig
 
-# Where is your server instance?
+# Where is your FLRig server instance?
 host=localhost
 #port=4532  # Default rigctld port
 port=12345  # Default flrig port
-

--- a/cloudlogbashcat.conf
+++ b/cloudlogbashcat.conf
@@ -13,7 +13,7 @@ cloudlogApiKey="1234567890123456"
 # What rig control software are we connecting to? (rigctld or flrig)
 rigControlSoftware=flrig
 
-# Where is your FLRig server instance?
+# Where is your rig control software server instance?
 host=localhost
 #port=4532  # Default rigctld port
 port=12345  # Default flrig port


### PR DESCRIPTION
I'm suggesting to explicitly mention FLRig in the server instance config section as it took me too long to realise the server instance was referring to where FLRig was running.

I'm sure I'm not the only one to miss that, but feel free to reject it.